### PR TITLE
`Editor` doesn't have to have `Converter` passed

### DIFF
--- a/Markdown.Editor.js
+++ b/Markdown.Editor.js
@@ -123,12 +123,14 @@
 
             panels = new PanelCollection(idPostfix);
             var commandManager = new CommandManager(hooks, getString);
-            var previewManager = new PreviewManager(markdownConverter, panels, function () { hooks.onPreviewRefresh(); });
+            var previewManager;
+            if(markdownConverter)
+                previewManager = new PreviewManager(markdownConverter, panels, function () { hooks.onPreviewRefresh(); });
             var undoManager, uiManager;
 
             if (!/\?noundo/.test(doc.location.href)) {
                 undoManager = new UndoManager(function () {
-                    previewManager.refresh();
+                    if(previewManager) previewManager.refresh();
                     if (uiManager) // not available on the first call
                         uiManager.setUndoRedoButtonStates();
                 }, panels);
@@ -142,9 +144,10 @@
             uiManager = new UIManager(idPostfix, panels, undoManager, previewManager, commandManager, options.helpButton, getString);
             uiManager.setUndoRedoButtonStates();
 
-            var forceRefresh = that.refreshPreview = function () { previewManager.refresh(true); };
-
-            forceRefresh();
+            if(previewManager){
+                var forceRefresh = that.refreshPreview = function () { previewManager.refresh(true); };
+                forceRefresh();
+            }
         };
 
     }
@@ -1358,7 +1361,8 @@
                     }
 
                     state.restore();
-                    previewManager.refresh();
+                    if(previewManager)
+                        previewManager.refresh();
                 };
 
                 var noCleanup = button.textOp(chunks, fixupInputArea);

--- a/demo/browser/demo_only_editor.html
+++ b/demo/browser/demo_only_editor.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>PageDown Demo Page</title>
+        <link rel="stylesheet" type="text/css" href="demo.css" />
+        <script type="text/javascript" src="../../Markdown.Converter.js"></script>
+        <script type="text/javascript" src="../../Markdown.Editor.js"></script>
+    </head>
+    <body>
+        <div class="wmd-panel">
+            <div id="wmd-button-bar"></div>
+            <textarea class="wmd-input" id="wmd-input">
+This is the *first* editor.
+------------------------------
+
+Just plain **Markdown**, except that the input is sanitized:
+
+<marquee>I'm the ghost from the past!</marquee>
+
+and that it implements "fenced blockquotes" via a plugin:
+
+"""
+Do it like this:
+
+1. Have idea.
+2. ???
+3. Profit!
+"""
+            </textarea>
+        </div>
+        <div id="wmd-preview" class="wmd-panel wmd-preview"></div>
+        
+        <script type="text/javascript">
+            (function () {
+                
+                var editor1 = new Markdown.Editor();
+                
+                editor1.run();
+            })();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
We shouldn't have to pass `new Editor(Converter)` if we don't need it. This decouples it.
