### PR TITLE
Update Markdown.Converter.js

### DIFF
--- a/Markdown.Converter.js
+++ b/Markdown.Converter.js
@@ -938,7 +938,7 @@ else
                     return result;
                 });
             } else {
-                whole_list = /(\n\n|^\n?)(([ ]{0,3}([*+-]|\d+[.])[ \t]+)[^\r]+?(~0|\n{2,}(?=\S)(?![ \t]*(?:[*+-]|\d+[.])[ \t]+)))/g;
+                whole_list = /(\n\n|^\n?)(([ ]{0,3}([*+-]|\d+[.])[ \t]+)[^\r]+?(~0|\n{2,}(?=\S)(?![ \t]*(?:[*+-]|\d+[.])[ \t]+)))/gm;
                 text = text.replace(whole_list, function (wholeMatch, m1, m2, m3) {
                     var runup = m1;
                     var list = m2;


### PR DESCRIPTION
allow user input list in the new line.

```
now issue example:
abc
+aaa
+aaa
```

this 'aaa' will not been parsed to ul/ol
