### PR TITLE
Removes 'use strict' from Markdown.Converter.js

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,6 +11,7 @@ Original Showdown code copyright (c) 2007 John Fraser
 
 Modifications and bugfixes (c) 2009 Dana Robinson
 Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
+Modifications and bugfixes (c) 2015 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Markdown.Converter.js
+++ b/Markdown.Converter.js
@@ -1,4 +1,3 @@
-"use strict";
 var Markdown;
 
 if (typeof exports === "object" && typeof require === "function") // we're in a CommonJS (e.g. Node.js) module


### PR DESCRIPTION
The global use of 'use strict' in Markdown.Converter.js can lead to this setting being applied to other libraries in an application which are not necessarily strict-conform if run through a compiler which concatenates scripts. If you wish to include 'use strict', it should be done in the scope of a single function only. This pull request simply removes 'use strict' since it easier than introducing it in function scope.
