### PR TITLE
Publishes Markdown explicitly to window object

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,6 +11,7 @@ Original Showdown code copyright (c) 2007 John Fraser
 
 Modifications and bugfixes (c) 2009 Dana Robinson
 Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
+Modifications and bugfixes (c) 2015 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Markdown.Converter.js
+++ b/Markdown.Converter.js
@@ -3,8 +3,10 @@ var Markdown;
 
 if (typeof exports === "object" && typeof require === "function") // we're in a CommonJS (e.g. Node.js) module
     Markdown = exports;
-else
+else {
     Markdown = {};
+    window.Markdown = Markdown;
+}
 
 // The following text is included for historical reasons, but should
 // be taken with a pinch of salt; it's not all true anymore.


### PR DESCRIPTION
Currently line 7 of Markdown.Sanitizer.js accesses the object Markdown from the window object. In certain cases, such as with the use of an "eval" compiler which gives functions local scope, this is incompatible with the use of 'use strict' in Markdown.Converter.js, since Markdown was not previously published to window. This pull request fixes the problem by explicitly publishing Markdown to the window object.
